### PR TITLE
feat: remove feedback display for immediate turn processing

### DIFF
--- a/src/app/features/game/game.component.html
+++ b/src/app/features/game/game.component.html
@@ -176,7 +176,7 @@
 				@for (t of types; track t) {
 				<button pb-action-chip [type]="t" [attr.data-pokemon-type]="t" [label]="typeLabels[t]" size="s"
 					class="type-chip" [class.selected]="selectedType1() === t || selectedType2() === t"
-					[class.pointer-events-none]="isShowingFeedback()" (action)="selectType(t)">
+					(action)="selectType(t)">
 				</button>
 				}
 			</div>

--- a/src/app/features/game/game.component.ts
+++ b/src/app/features/game/game.component.ts
@@ -73,8 +73,7 @@ export class GameComponent implements OnInit {
   // Staging Preview Outcome
   stagingOutcome = signal<'critical' | 'effective' | 'neutral' | 'resisted' | 'immune' | 'perfect' | 'partial' | 'none' | null>(null);
   stagingMultiplier = signal<number | null>(null); // For easy mode
-  isShowingFeedback = signal(false);
-  isFeedbackFadingOut = signal(false); // Controls fade-out animation
+
 
   // Computed staging background color
   stagingBackgroundColor = computed(() => {
@@ -177,7 +176,7 @@ export class GameComponent implements OnInit {
   // Actions
   selectType(type: PokemonType) {
     if (this.isGameOver()) return;
-    if (this.isShowingFeedback()) return; // Prevent selection during feedback
+
 
     if (this.mode() === 'attack') {
       if (this.selectedType1() === type) {
@@ -205,7 +204,7 @@ export class GameComponent implements OnInit {
 
   setMode(m: 'attack' | 'solve') {
     if (this.isGameOver()) return;
-    if (this.isShowingFeedback()) return; // Prevent mode switch during feedback
+
     this.mode.set(m);
     // Clear second type when switching to attack mode
     if (m === 'attack' && this.selectedType2()) {
@@ -262,17 +261,12 @@ export class GameComponent implements OnInit {
 
   submitAction() {
     if (this.isGameOver()) return;
-    if (this.isShowingFeedback()) return; // Prevent submit during feedback
 
     const type1 = this.selectedType1();
     const type2 = this.selectedType2();
 
     // Check validity
     if (!type1) return; // Both modes require at least type1
-
-    // Show feedback immediately upon submission
-    this.updateStagingPreview();
-    this.cdr.detectChanges();
 
     // Find current empty slot (should correspond to currentTurn - 1)
     const index = this.currentTurn() - 1;
@@ -333,26 +327,11 @@ export class GameComponent implements OnInit {
       }
     }
 
-    // Show feedback for 0.5 second (200ms visible + 300ms fade-out)
-    this.isShowingFeedback.set(true);
-    this.isFeedbackFadingOut.set(false);
-
-    // Start fade-out after 200ms
-    setTimeout(() => {
-      this.isFeedbackFadingOut.set(true);
-      this.cdr.detectChanges();
-    }, 200);
-
-    // Clear after full 0.5 second (including fade-out animation)
-    setTimeout(() => {
-      this.selectedType1.set(null);
-      this.selectedType2.set(null);
-      this.stagingOutcome.set(null);
-      this.stagingMultiplier.set(null);
-      this.isShowingFeedback.set(false);
-      this.isFeedbackFadingOut.set(false);
-      this.cdr.detectChanges();
-    }, 500);
+    // Clear selections immediately after submission
+    this.selectedType1.set(null);
+    this.selectedType2.set(null);
+    this.stagingOutcome.set(null);
+    this.stagingMultiplier.set(null);
   }
 
   updateMemo(type: PokemonType, outcome: string) {


### PR DESCRIPTION
📝 PRタイトルの命名規則:
[type]: [description]

タイプ一覧:
- ✨ feat: 新機能
- 🐛 fix: バグ修正
- 📚 docs: ドキュメント
- 🎨 style: スタイル変更
- ♻️ refactor: リファクタリング
- ⚡ perf: パフォーマンス改善
- 🧪 test: テスト
- 🏗️ build: ビルド
- 👷 ci: CI/CD
- 🔧 chore: その他

説明の書き方: 
- 英語で書くこと
- 1行で説明すること
- すべて小文字で書くこと

例: feat: add sound effects and toggle switch

## 💡 概要
- 回答送信後のフィードバック表示機能を削除し、即座に履歴へ反映されるようにすることでゲームのテンポを改善

## 📝 変更内容
- isShowingFeedback および isFeedbackFadingOut シグナルを削除
- フィードバック表示のための setTimeout 遅延処理を削除
- 回答送信後、即座に選択状態をクリアするように変更
- タイプチップの pointer-events-none クラスバインディングを削除
- selectType および setMode メソッドからフィードバック中のガード処理を削除

## 🔗 関連Issue
Closes #50

## 📷 スクリーンショット（該当する場合）
ローカルで動作確認済み

## ✅ チェックリスト
- [x] ビルドが成功する（npm run build）
- [x] Lintエラーがない（npm run lint）
- [x] テストが通る（npm run test）
- [x] コミットメッセージが規約に従っている（feat:, fix:, chore:など）
- [x] ブランチ名が規約に従っている（feature/, fix/, chore/など）
- [x] 必要に応じてドキュメントを更新した

## 📖 レビュー用語集
| 用語 | 意味 | 説明 |
|------|------|------|
| **LGTM** | Looks Good To Me | 良いと思います |
| **WIP** | Work In Progress | 対応中 |
| **FYI** | For Your Information | 参考までに |
| **must** | must | 必須 |
| **want** | want | できれば |
| **imo** | in my opinion | 私の意見では |
| **nits** | nitpick | 些細な指摘（重箱の隅をつつくの意味） |

## 📌 補足事項
- 当初は表示時間を延長する方向で検討していたが、フィードバック表示自体を削除する方がゲームのテンポが良くなると判断
- 回答結果は履歴に即座に反映されるため、ユーザー体験の低下はない